### PR TITLE
Show the appropriate error message if no action or workflow subcommand is specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/homoluctus/gavi#readme",
   "engines": {
     "node": ">=14.16.0",
-    "yarn": ">=1.22.10"
+    "yarn": ">=1.22.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,14 @@ import { Reporter } from './reporter';
 const { version } = require('../package.json');
 
 export async function run(): Promise<void> {
-  const argv = parseArgv();
-  logger.level = argv.logLevel;
-  logger.silent = argv.silent;
-
   try {
+    const argv = parseArgv();
+
+    logger.level = argv.logLevel;
+    logger.silent = argv.silent;
+
     const errors = await validate(argv.filename, argv.schemaType);
+
     if (errors) {
       const reporter = new Reporter(argv.format);
       reporter.dump(errors);
@@ -72,9 +74,14 @@ function parseArgv(): Argv {
     .usage('Usage: $0 <command> [options]')
     .help().argv;
 
+  const schemaType = argv._[0] as SchemaType;
+  if (!['action', 'workflow'].includes(schemaType)) {
+    throw new Error('Please specify "action" or "workflow" subcommand');
+  }
+
   return {
     filename: argv.filename as string,
-    schemaType: argv._[0] as SchemaType,
+    schemaType,
     format: argv.format as ReportFormat,
     logLevel: nameToNum[argv.logLevel],
     silent: argv.silent


### PR DESCRIPTION
## TODO

- [x] Add judge whether subcommand is proper.
- [x] Change the error message

## Motivation (Reason)

In version 0.1.0, show the following error message if no action or workflow subcommand:
![Screenshot from 2021-06-07 10-25-49](https://user-images.githubusercontent.com/22735969/120947552-dba6a080-c77a-11eb-9a41-08424b7ee258.png)

this message is not user friendly and confusing.