### PR TITLE
ci: Remove GitHub release creation from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,13 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [created]
 
 env:
   WORKFLOW_NODE_VERSION: '14'
 
 jobs:
-  github:
-    name: Create release package
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.WORKFLOW_NODE_VERSION }}
-
-      - name: Build
-        run: |
-          yarn install --frozen-lockfile
-          yarn run build
-
-      - uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   npm:
     name: Publish to NPM registry
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Reason

- twitter workflow trigger does not work when create GitHub release on GitHub Actions.